### PR TITLE
sugestões para incrementar a documentação do dataset Cirurgias (e demais)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Cirurgias
+Cirurgias realizadas por porte
+
+[![frictionless](https://github.com/fhemig/Cirurgias/actions/workflows/frictionless.yaml/badge.svg)](https://github.com/fhemig/Cirurgias/actions/workflows/frictionless.yaml)

--- a/datapackage.json
+++ b/datapackage.json
@@ -81,6 +81,7 @@
   "description": "Cirurgias realizadas em bloco cirúrgico por porte.",
   "homepage": "https://github.com/fhemig",
   "owner_org": "fundacao-hospitalar-do-estado-de-minas-gerais-fhemig",
+  "frequência de atualização":"mensal",
    "temporal": {
     "start": "2016-01-01",
     "end": "2022-04-30"

--- a/datapackage.json
+++ b/datapackage.json
@@ -81,6 +81,10 @@
   "description": "Cirurgias realizadas em bloco cirúrgico por porte.",
   "homepage": "https://github.com/fhemig",
   "owner_org": "fundacao-hospitalar-do-estado-de-minas-gerais-fhemig",
+   "temporal": {
+    "start": "2016-01-01",
+    "end": "2022-04-30"
+  },
   "contributors": [
     {
       "title": "Maristela Guimarães Cáfaro Ferreira",

--- a/datapackage.json
+++ b/datapackage.json
@@ -88,7 +88,8 @@
   "contributors": [
     {
       "title": "Maristela Guimarães Cáfaro Ferreira",
-      "role": "author"
+      "role": "author",
+      "email": "gtgi.codi@fhemig.mg.gov.br"
     }
   ],
   "licenses": [


### PR DESCRIPTION
@maristelagcafaro bom dia,
Conforme últimos emails, estou sugerindo as alterações:

Para o conjunto das _Cirurgias_: 

- adição da etiqueta de validação (badge) dos dados, como já está nos conjuntos do CRIB e do APACHE (ainda assim, acho que vale uma descrição desse conjunto como o dos outros 2 - adicionando, p. ex., a fonte de classificação do porte das cirurgias);

Para todos os conjuntos, exemplificado nesse do __Cirurgias_:

- adição da frequência de atualização (será mensal, certo?);

- adição do _temporal_, propriedade que sinaliza o início e o fim da série histórica representada em cada conjunto;

- adição do e-mail institucional de contato, junto da autoria do conjunto 

A visualização de como fica está em https://homologa.cge.mg.gov.br/dataset/cirurgias?activity_id=e67834ba-a86e-4226-a675-4e3f94f67c41